### PR TITLE
MPMP-73: Change profileVerticalDivider color

### DIFF
--- a/feature/profile/presentation/src/commonMain/kotlin/dev/kigya/mindplex/feature/profile/presentation/ui/theme/ProfileTheme.kt
+++ b/feature/profile/presentation/src/commonMain/kotlin/dev/kigya/mindplex/feature/profile/presentation/ui/theme/ProfileTheme.kt
@@ -64,8 +64,8 @@ internal object ProfileTheme : MindplexTheme() {
     val MindplexColorScheme.profileVerticalDivider
         @Composable
         get() = this provides MindplexDynamicColor(
-            light = super.color.iris10,
-            dark = super.color.iris10,
+            light = super.color.iris20,
+            dark = super.color.white20,
         )
 
     val MindplexColorScheme.profileThemeNameText


### PR DESCRIPTION
1. Протестировал на различных устройствах 
2. Проверил различную ориентацию и также темы 

(Темная тема приложения) использовал цвет white20 
![Image](https://github.com/user-attachments/assets/425126b5-611c-4d0a-9cbe-4c11826b3ffc)
(Темная тема фигма) в фигме white 20%
![Image](https://github.com/user-attachments/assets/d81d3309-2bed-49c5-8ac2-e4ffff39ab0a)

(Светлая тема приложения) использовал цвет iris20
![Image](https://github.com/user-attachments/assets/778cca26-893e-445f-830e-c699cb9d7a16)
(Светлая тема фигма) в фигме iris 20%
![Image](https://github.com/user-attachments/assets/3f03817d-a449-4def-b093-2d01e1676c76)

IOS
(Светлая тема приложения) 
![Image](https://github.com/user-attachments/assets/37a3a7f5-7aec-4a34-ab50-2ddbc2837e33)
(Темная тема приложения) 
![Image](https://github.com/user-attachments/assets/7ec655ac-d3a4-4e2b-90db-103f2b13899f)