### PR TITLE
MPMP-74: Changed the indentation in LeaderboardScreenHeader

### DIFF
--- a/feature/leaderboard/presentation/src/commonMain/kotlin/dev/kigya/mindplex/feature/leaderboard/presentation/block/LeaderboardScreenHeader.kt
+++ b/feature/leaderboard/presentation/src/commonMain/kotlin/dev/kigya/mindplex/feature/leaderboard/presentation/block/LeaderboardScreenHeader.kt
@@ -2,6 +2,7 @@ package dev.kigya.mindplex.feature.leaderboard.presentation.block
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import dev.kigya.mindplex.core.presentation.uikit.MindplexText
@@ -16,6 +17,7 @@ import org.jetbrains.compose.resources.stringResource
 internal fun LeaderboardScreenHeader(modifier: Modifier = Modifier) {
     Row(modifier = modifier.fillMaxWidth()) {
         MindplexText(
+            modifier = Modifier.padding(vertical = LeaderboardTheme.dimension.dp12.value),
             value = stringResource(Res.string.leaderboard),
             color = LeaderboardTheme.colorScheme.leaderboardTitleText,
             typography = LeaderboardTheme.typography.leaderboardTitleText,


### PR DESCRIPTION
1. Протестировал на каждом из устройств начиная с обычных эмуляторов,  заканчивая физическими 
2. Протестировал различную ориентацию 
3. Проверил IOS 
4. Проверил планшетную версию 
5. Проверил инспектор 
![Screenshot 2025-04-28 at 13 42 20](https://github.com/user-attachments/assets/63925bbe-8e78-4b8a-be49-0f0e227db531)
![Screenshot 2025-04-28 at 13 42 29](https://github.com/user-attachments/assets/ba9d6fd9-76a4-47e5-b35e-965fbb4ae23e)

Демонстрация работы анимации
[Screen_recording_20250428_133716.webm](https://github.com/user-attachments/assets/97970a87-e1f1-415e-be64-bdcb2052e095)

Вариант с другим текстом 
[Screen_recording_20250428_133520.webm](https://github.com/user-attachments/assets/57f5c88a-a84f-4153-abbf-571b5ad094fa)
