### PR TITLE
MPMP-62: Fix calculating score points when time is up

### DIFF
--- a/feature/game/domain/src/commonMain/kotlin/dev/kigya/mindplex/feature/game/domain/model/QuestionValidationDomainModel.kt
+++ b/feature/game/domain/src/commonMain/kotlin/dev/kigya/mindplex/feature/game/domain/model/QuestionValidationDomainModel.kt
@@ -1,8 +1,8 @@
 package dev.kigya.mindplex.feature.game.domain.model
 
 data class QuestionValidationDomainModel(
-    val isAnswerCorrect: Boolean,
     val question: String,
+    val validationType: ValidationType,
     val results: List<QuestionDomainResult>,
 )
 
@@ -15,4 +15,5 @@ enum class ValidationType {
     INCORRECT,
     NEUTRAL,
     CORRECT,
+    NO_ANSWER,
 }

--- a/feature/game/domain/src/commonMain/kotlin/dev/kigya/mindplex/feature/game/domain/usecase/UpdateScoreUseCase.kt
+++ b/feature/game/domain/src/commonMain/kotlin/dev/kigya/mindplex/feature/game/domain/usecase/UpdateScoreUseCase.kt
@@ -3,6 +3,7 @@ package dev.kigya.mindplex.feature.game.domain.usecase
 import dev.kigya.mindplex.core.domain.interactor.base.BaseSuspendUseCase
 import dev.kigya.mindplex.core.domain.profile.contract.UserProfileDatabaseRepositoryContract
 import dev.kigya.mindplex.core.domain.profile.contract.UserProfileNetworkRepositoryContract
+import dev.kigya.mindplex.feature.game.domain.model.ValidationType
 import dev.kigya.mindplex.feature.login.domain.contract.SignInPreferencesRepositoryContract
 import dev.kigya.outcome.getOrNull
 import kotlinx.coroutines.flow.first
@@ -11,17 +12,18 @@ class UpdateScoreUseCase(
     private val profileDatabaseRepositoryContract: UserProfileDatabaseRepositoryContract,
     private val profileNetworkRepositoryContract: UserProfileNetworkRepositoryContract,
     private val signInPreferencesRepositoryContract: SignInPreferencesRepositoryContract,
-) : BaseSuspendUseCase<Unit, Boolean>() {
+) : BaseSuspendUseCase<Unit, ValidationType>() {
 
-    override suspend operator fun invoke(params: Boolean) {
+    override suspend operator fun invoke(params: ValidationType) {
         val token = signInPreferencesRepositoryContract.userId.first().orEmpty()
         val currentScore =
             profileDatabaseRepositoryContract.getUserScore(token).getOrNull() ?: return
 
-        val newScore = if (params) {
-            currentScore + CORRECT_REWARD
-        } else {
-            currentScore + INCORRECT_REWARD
+        val newScore = when (params) {
+            ValidationType.CORRECT -> currentScore + CORRECT_REWARD
+            ValidationType.INCORRECT -> currentScore + INCORRECT_REWARD
+            ValidationType.NO_ANSWER -> currentScore + NO_REWARD
+            ValidationType.NEUTRAL -> return
         }
 
         profileDatabaseRepositoryContract.saveUserScore(token, newScore)
@@ -31,5 +33,6 @@ class UpdateScoreUseCase(
     private companion object {
         const val CORRECT_REWARD = 2
         const val INCORRECT_REWARD = 1
+        const val NO_REWARD = 0
     }
 }

--- a/feature/game/domain/src/commonMain/kotlin/dev/kigya/mindplex/feature/game/domain/usecase/ValidateQuestionUseCase.kt
+++ b/feature/game/domain/src/commonMain/kotlin/dev/kigya/mindplex/feature/game/domain/usecase/ValidateQuestionUseCase.kt
@@ -41,16 +41,26 @@ class ValidateQuestionUseCase(
                         }
                         QuestionDomainResult(idx, vt)
                     }
-
+                    val validationType = defineValidationType(params, results, userAnswerIndex)
                     val validation = QuestionValidationDomainModel(
-                        isAnswerCorrect = results.none { it.validationType == ValidationType.INCORRECT } &&
-                            userAnswerIndex != -1,
                         question = questionDomain.question,
+                        validationType = validationType,
                         results = results,
                     )
-
                     Outcome.success(validation)
                 },
             )
     }
+}
+
+private fun defineValidationType(
+    params: UserChoiceDomainModel,
+    results: List<QuestionDomainResult>,
+    userAnswerIndex: Int,
+): ValidationType = when {
+    params.isAnswered.not() -> ValidationType.NO_ANSWER
+    results.none { it.validationType == ValidationType.INCORRECT } && userAnswerIndex != -1 ->
+        ValidationType.CORRECT
+
+    else -> ValidationType.INCORRECT
 }

--- a/feature/game/presentation/src/commonMain/kotlin/dev/kigya/mindplex/feature/game/presentation/ui/GameScreenViewModel.kt
+++ b/feature/game/presentation/src/commonMain/kotlin/dev/kigya/mindplex/feature/game/presentation/ui/GameScreenViewModel.kt
@@ -123,7 +123,7 @@ class GameScreenViewModel(
                 updateState { copy(stubErrorType = error.toStubErrorType()) }
             },
             onSuccess = { questionValidation: QuestionValidationDomainModel ->
-                updateScoreUseCase(questionValidation.isAnswerCorrect)
+                updateScoreUseCase(questionValidation.validationType)
                 val updatedAnswers = getState().answers.mapIndexed { i, answer ->
                     val domainResult = questionValidation.results.find { it.index == i }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ kotlin.code.style=official
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 #KMP
-build-stage=debug
+build-stage=release

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ kotlin.code.style=official
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 #KMP
-build-stage=release
+build-stage=debug


### PR DESCRIPTION
Fix calculating score points when time is out
1. Correct points when time is out
Android:
[android-IS-62.webm](https://github.com/user-attachments/assets/2deb16e3-b90c-4801-8b95-699b1e4ee1fe)
iOS:
https://github.com/user-attachments/assets/a0be5326-2c9b-40b0-aa90-4c40bb7c4d4b
2.Correct points in user profile
Android:
[Screen_recording_20250514_153459.webm](https://github.com/user-attachments/assets/c76ba910-0f77-4fe4-8984-d287e765c02f)
iOS:
https://github.com/user-attachments/assets/9ccfebfd-4213-4639-9839-fee06b27f23d
Пр не затрагивает часть с ui



